### PR TITLE
Remove Hazelcast version from the guide text

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -87,7 +87,6 @@ We want to use Hazelcast as the JCache provider. The good news is that all you h
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-all</artifactId>
-    <version>4.0.2</version>
 </dependency>
 ----
 


### PR DESCRIPTION
It's difficult to maintain.